### PR TITLE
Update dependencies to latest version

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,85 +4,86 @@ const psList = require('ps-list');
 const pidFromPort = require('pid-from-port');
 const util = require('./lib/util');
 
-const loadProcesses = () => {
+const loadProcesses = async () => {
 	if (alfy.input.startsWith(':')) {
 		const search = alfy.input.slice(1);
 
-		return Promise.all([
+		const result = await Promise.all([
 			pidFromPort.list(),
 			psList({all: false})
-		]).then(result => {
-			const ports = result[0];
-			const processList = result[1];
+		]);
 
-			// Swap port and pid
-			const pidMap = new Map();
-			for (const entry of ports.entries()) {
-				const port = String(entry[0]);
+		const ports = result[0];
+		const processList = result[1];
 
-				if (!port.includes(search)) {
-					// Filter out results which don't match the search term
-					continue;
-				}
+		// Swap port and pid
+		const pidMap = new Map();
+		for (const entry of ports.entries()) {
+			const port = String(entry[0]);
 
-				pidMap.set(entry[1], String(entry[0]));
+			if (!port.includes(search)) {
+				// Filter out results which don't match the search term
+				continue;
 			}
 
-			return processList
-				.map(process => Object.assign({}, process, {port: pidMap.get(process.pid)}))
-				.filter(process => Boolean(process.port));
-		});
+			pidMap.set(entry[1], String(entry[0]));
+		}
+
+		return processList
+			.map(process => ({...process, ...{port: pidMap.get(process.pid)}}))
+			.filter(process => Boolean(process.port));
 	}
 
-	return psList().then(data => alfy.inputMatches(data, 'name'));
+	const processList = await psList();
+	return alfy.inputMatches(processList, 'name');
 };
 
-loadProcesses()
-	.then(processes => {
-		const items = processes
-			.filter(process => !process.name.endsWith(' Helper'))
-			.map(process => {
-				const cleanedPath = process.cmd.replace(/\.app\/Contents\/.*$/, '.app');
+(async () => {
+	const processes = await loadProcesses();
+	const items = processes
+		.filter(process => !process.name.endsWith(' Helper'))
+		.map(process => {
+			const cleanedPath = process.cmd.replace(/\.app\/Contents\/.*$/, '.app');
 
-				// TODO: Use the `process.path` property in `ps-list` when implemented there
-				// The below can be removed then
-				const pathForIcon = cleanedPath.replace(/ -.*/, ''); // Removes arguments
+			// TODO: Use the `process.path` property in `ps-list` when implemented there
+			// The below can be removed then
+			const pathForIcon = cleanedPath.replace(/ -.*/, ''); // Removes arguments
 
-				let subtitle = cleanedPath;
+			let subtitle = cleanedPath;
 
-				if (process.port) {
-					// TODO; Use `process.path` property
-					subtitle = `${process.port} - ${subtitle}`;
-				}
+			if (process.port) {
+				// TODO; Use `process.path` property
+				subtitle = `${process.port} - ${subtitle}`;
+			}
 
-				return {
-					title: process.name,
-					autocomplete: process.name,
-					subtitle,
-					arg: process.pid,
-					icon: {
-						type: 'fileicon',
-						path: pathForIcon
+			return {
+				title: process.name,
+				autocomplete: process.name,
+				subtitle,
+				arg: process.pid,
+				icon: {
+					type: 'fileicon',
+					path: pathForIcon
+				},
+				mods: {
+					shift: {
+						subtitle: `CPU ${process.cpu}%`
 					},
-					mods: {
-						shift: {
-							subtitle: `CPU ${process.cpu}%`
-						},
-						alt: {
-							subtitle: 'Force kill',
-							arg: JSON.stringify({
-								alfredworkflow: {
-									arg: process.pid,
-									variables: {
-										force: true
-									}
+					alt: {
+						subtitle: 'Force kill',
+						arg: JSON.stringify({
+							alfredworkflow: {
+								arg: process.pid,
+								variables: {
+									force: true
 								}
-							})
-						}
+							}
+						})
 					}
-				};
-			})
-			.sort(util.sorter);
+				}
+			};
+		})
+		.sort(util.sorter);
 
-		alfy.output(items);
-	});
+	alfy.output(items);
+})();

--- a/kill.js
+++ b/kill.js
@@ -1,6 +1,6 @@
 'use strict';
 const fkill = require('fkill');
 
-fkill(parseInt(process.argv[2], 10), {
+fkill(Number.parseInt(process.argv[2], 10), {
 	force: Boolean(process.env.force)
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,18 +1,18 @@
 'use strict';
-const process = [
+const process = new Set([
 	'node',
 	'python'
-];
+]);
 
 const processCompare = (a, b) => {
 	const aTitle = a.title.toLowerCase();
 	const bTitle = b.title.toLowerCase();
 
-	if (process.indexOf(aTitle) !== -1) {
+	if (process.has(aTitle)) {
 		return -1;
 	}
 
-	if (process.indexOf(bTitle) !== -1) {
+	if (process.has(bTitle)) {
 		return 1;
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "github.com/SamVerschueren"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava",
@@ -38,15 +38,15 @@
 		"force"
 	],
 	"dependencies": {
-		"alfy": "^0.8.0",
-		"fkill": "^5.3.0",
-		"pid-from-port": "^1.1.2",
-		"ps-list": "^4.0.0"
+		"alfy": "^0.10.0",
+		"fkill": "^7.1.0",
+		"pid-from-port": "^1.1.3",
+		"ps-list": "^7.2.0"
 	},
 	"devDependencies": {
-		"alfy-test": "^0.3.0",
+		"alfy-test": "^0.4.0",
 		"ava": "*",
-		"get-port": "^3.2.0",
+		"get-port": "^5.1.1",
 		"xo": "*"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,16 @@
 # alfred-fkill [![Build Status](https://travis-ci.org/SamVerschueren/alfred-fkill.svg?branch=master)](https://travis-ci.org/SamVerschueren/alfred-fkill)
 
-> [Alfred 3](https://www.alfredapp.com) workflow to fabulously search and kill processes
+> [Alfred 3/4](https://www.alfredapp.com) workflow to fabulously search and kill processes
 
 <img src="screenshot.png" width="694">
 
-
 ## Install
 
-```
-$ npm install --global alfred-fkill
+```bash
+npm install --global alfred-fkill
 ```
 
-*Requires [Node.js](https://nodejs.org) 4+ and the Alfred [Powerpack](https://www.alfredapp.com/powerpack/).*
-
+*Requires [Node.js](https://nodejs.org) 10+ and the [Alfred Powerpack](https://www.alfredapp.com/powerpack/).*
 
 ## Usage
 
@@ -24,12 +22,10 @@ Select an item and press <kbd>Enter</kbd> to kill the process.<br>
 Hold <kbd>Shift</kbd> to show the used CPU percentage.<br>
 Hold <kbd>Alt</kbd> and press <kbd>Enter</kbd> to force kill the process.
 
-
 ## Related
 
 - [fkill](https://github.com/sindresorhus/fkill) - API for this workflow
 - [fkill-cli](https://github.com/sindresorhus/fkill-cli) - CLI version of this workflow
-
 
 ## License
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
-import childProcess from 'child_process';
-import test from 'ava';
-import alfyTest from 'alfy-test';
-import getPort from 'get-port';
+const test = require('ava');
+const alfyTest = require('alfy-test');
+const childProcess = require('child_process');
+const getPort = require('get-port');
 
 test('search by name', async t => {
 	const alfy = alfyTest();


### PR DESCRIPTION
- I tried to install this on MacOS 10.15 with Alfred 4 and the version of Alfy wasn't working so I started by updating Alfy to `0.10.0`
- I then realized that the `xo: "*"` dependency has changed the lint rules since the last push, and was forced to remove any `.then()` statements and fix a couple of array things
- Then I decided to go ahead and update the rest of the dependencies since there were no breaking changes in the updates
- Then, I had to change the imports in the tests to requires to fix a node module declaration error
- Lastly I updated the readme to list that it now works with Alfred 4 (also my MD lint auto fixed some spacing things)